### PR TITLE
bug: fix csp datasource for management group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,5 +67,5 @@ data "azapi_resource_list" "subscription_metadata" {
 resource "azurerm_management_group_subscription_association" "this" {
   count               = var.channel == "csp" ? 1 : 0
   management_group_id = var.parent_management_group_id
-  subscription_id     = data.azurerm_subscriptions.this.subscriptions[0].subscription_id
+  subscription_id     = data.azurerm_subscriptions.this.subscriptions[0].id
 }

--- a/main.tf
+++ b/main.tf
@@ -67,5 +67,5 @@ data "azapi_resource_list" "subscription_metadata" {
 resource "azurerm_management_group_subscription_association" "this" {
   count               = var.channel == "csp" ? 1 : 0
   management_group_id = var.parent_management_group_id
-  subscription_id     = data.azapi_resource_list.subscription_metadata.output.id[0]
+  subscription_id     = data.azurerm_subscriptions.this.subscriptions[0].subscription_id
 }


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
changed the datasource for the csp azurerm_management_group_subscription_association, it errors out since the resource would give an error, and the data source will assume creation.
hence the plan will succeed instead of fail.

**:rocket: Motivation**
The plan was failing on absence of the subscription since the resource would query something not present yet, the data source will assume and the plan wil succeed.

